### PR TITLE
Add dataset export script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # OS
 .DS_Store
 
+# Datasets
+*.json
+
 *.pyo
 *.pyd
 

--- a/export.py
+++ b/export.py
@@ -1,10 +1,12 @@
-import os
-import frontmatter
 import json
 from pathlib import Path
+import frontmatter
 
 
-def export_dataset(root_path="python_qa", output_file="training_dataset.json"):
+def export_dataset(
+    root_path: str = "python_qa",
+    output_file: str = "training_dataset.json",
+) -> None:
     """
     Parses all .md files, formats them into a JSON structure for LLM training,
     and saves them to a single file.
@@ -34,7 +36,10 @@ def export_dataset(root_path="python_qa", output_file="training_dataset.json"):
                 }
                 all_entries.append(entry)
             else:
-                print(f"Warning: Skipping {md_file} due to missing 'Question' or 'Answer' header.")
+                print(
+                    f"Warning: Skipping {md_file} due to missing "
+                    "'Question' or 'Answer' header."
+                )
 
         except Exception as e:
             print(f"Error parsing {md_file}: {e}")
@@ -43,7 +48,9 @@ def export_dataset(root_path="python_qa", output_file="training_dataset.json"):
     with open(output_file, 'w', encoding='utf-8') as f:
         json.dump(all_entries, f, indent=2, ensure_ascii=False)
 
-    print(f"Export complete. {len(all_entries)} entries saved to {output_file}.")
+    print(
+        f"Export complete. {len(all_entries)} entries saved to {output_file}."
+    )
 
 
 if __name__ == "__main__":

--- a/export.py
+++ b/export.py
@@ -1,0 +1,50 @@
+import os
+import frontmatter
+import json
+from pathlib import Path
+
+
+def export_dataset(root_path="python_qa", output_file="training_dataset.json"):
+    """
+    Parses all .md files, formats them into a JSON structure for LLM training,
+    and saves them to a single file.
+    """
+    all_entries = []
+    root_dir = Path(root_path)
+
+    print(f"Starting export to {output_file}...")
+
+    # Recursively find all markdown files
+    for md_file in root_dir.glob('**/*.md'):
+        try:
+            post = frontmatter.load(md_file)
+            content = post.content.strip()
+
+            # Split content into question and answer
+            if "# Question" in content and "# Answer" in content:
+                parts = content.split("# Answer")
+                question_part = parts[0].replace("# Question", "").strip()
+                answer_part = parts[1].strip()
+
+                # Define the target JSON structure for each entry
+                entry = {
+                    "instruction": question_part,
+                    "response": answer_part,
+                    "metadata": post.metadata
+                }
+                all_entries.append(entry)
+            else:
+                print(f"Warning: Skipping {md_file} due to missing 'Question' or 'Answer' header.")
+
+        except Exception as e:
+            print(f"Error parsing {md_file}: {e}")
+
+    # Write the assembled data to the output file
+    with open(output_file, 'w', encoding='utf-8') as f:
+        json.dump(all_entries, f, indent=2, ensure_ascii=False)
+
+    print(f"Export complete. {len(all_entries)} entries saved to {output_file}.")
+
+
+if __name__ == "__main__":
+    export_dataset()


### PR DESCRIPTION
## Summary
- add export.py to convert markdown QA entries to JSON
- ignore dataset JSON files in `.gitignore`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68636b6ca3348322bc6ea53728f1c25d