### PR TITLE
Implement chain_of_thought parsing in export script

### DIFF
--- a/export.py
+++ b/export.py
@@ -26,14 +26,13 @@ def export_dataset(
             if "# Question" in content and "# Answer" in content:
                 think_part = None
 
-                question_part = (
-                    content.split("# Think")[0].replace("# Question", "").strip()
-                )
+                question_raw = content.split("# Think")[0]
+                question_part = question_raw.replace("# Question", "").strip()
 
                 if "# Think" in content:
-                    think_part = (
-                        content.split("# Think")[1].split("# Answer")[0].strip()
-                    )
+                    think_section = content.split("# Think")[1]
+                    think_raw = think_section.split("# Answer")[0]
+                    think_part = think_raw.strip()
                     answer_part = content.split("# Answer")[1].strip()
                 else:
                     answer_part = content.split("# Answer")[1].strip()
@@ -59,7 +58,10 @@ def export_dataset(
     with open(output_file, "w", encoding="utf-8") as f:
         json.dump(all_entries, f, indent=2, ensure_ascii=False)
 
-    print(f"Export complete. {len(all_entries)} entries saved to {output_file}.")
+    msg = (
+        f"Export complete. {len(all_entries)} entries saved to {output_file}."
+    )
+    print(msg)
 
 
 if __name__ == "__main__":

--- a/export.py
+++ b/export.py
@@ -17,22 +17,33 @@ def export_dataset(
     print(f"Starting export to {output_file}...")
 
     # Recursively find all markdown files
-    for md_file in root_dir.glob('**/*.md'):
+    for md_file in root_dir.glob("**/*.md"):
         try:
             post = frontmatter.load(md_file)
             content = post.content.strip()
 
-            # Split content into question and answer
+            # Split content into question, think, and answer
             if "# Question" in content and "# Answer" in content:
-                parts = content.split("# Answer")
-                question_part = parts[0].replace("# Question", "").strip()
-                answer_part = parts[1].strip()
+                think_part = None
+
+                question_part = (
+                    content.split("# Think")[0].replace("# Question", "").strip()
+                )
+
+                if "# Think" in content:
+                    think_part = (
+                        content.split("# Think")[1].split("# Answer")[0].strip()
+                    )
+                    answer_part = content.split("# Answer")[1].strip()
+                else:
+                    answer_part = content.split("# Answer")[1].strip()
 
                 # Define the target JSON structure for each entry
                 entry = {
                     "instruction": question_part,
                     "response": answer_part,
-                    "metadata": post.metadata
+                    "chain_of_thought": think_part,
+                    "metadata": post.metadata,
                 }
                 all_entries.append(entry)
             else:
@@ -45,12 +56,10 @@ def export_dataset(
             print(f"Error parsing {md_file}: {e}")
 
     # Write the assembled data to the output file
-    with open(output_file, 'w', encoding='utf-8') as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         json.dump(all_entries, f, indent=2, ensure_ascii=False)
 
-    print(
-        f"Export complete. {len(all_entries)} entries saved to {output_file}."
-    )
+    print(f"Export complete. {len(all_entries)} entries saved to {output_file}.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support optional `# Think` section when exporting dataset

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68636fba791083229d47647abca2d7c6