### PR TITLE
Require ::END:: terminator in entry script

### DIFF
--- a/create_entry.py
+++ b/create_entry.py
@@ -48,9 +48,7 @@ def select_from_list(options, prompt_text):
 
 
 def get_multiline_input(prompt):
-    """
-    Collects multi-line input from the user until the terminator is entered.
-    """
+    """Collect multi-line input until the terminator is entered."""
     lines = []
     print(f"{prompt} (type '{INPUT_TERMINATOR}' on a new line when finished):")
     while True:
@@ -85,7 +83,8 @@ def create_new_entry():
 
     # 2. Get Content (Question, Answer, and optional Thinking)
     print("\n--- Enter Content ---")
-    question = input("Question: ").strip()
+    # All text fields require the terminator to finish input
+    question = get_multiline_input("Question").strip()
 
     if not question:
         print("\nError: Question cannot be empty. Aborting.")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from code_coil import hello
 
 

--- a/tests/test_create_entry.py
+++ b/tests/test_create_entry.py
@@ -1,0 +1,58 @@
+import sys
+import builtins
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import create_entry
+
+
+def test_get_multiline_input_long_and_odd(monkeypatch):
+    lines = [
+        "weird start !!!",
+        """long line with special chars !@#$%^&*()""" + "x" * 500,
+        "::END::",
+    ]
+    iterator = iter(lines)
+    monkeypatch.setattr(builtins, "input", lambda *args: next(iterator))
+    result = create_entry.get_multiline_input("prompt")
+    expected = "\n".join(lines[:-1])
+    assert result == expected
+
+
+def test_create_entry_with_long_inputs(tmp_path, monkeypatch):
+    root = tmp_path / "python_qa"
+    root.mkdir()
+
+    long_question = "Q" * 500
+    long_answer = "A" * 800
+    long_thinking = "T" * 700
+
+    inputs = [
+        "topic1",  # topic
+        "subtopic1",  # subtopic
+        long_question,
+        "::END::",
+        long_answer,
+        "::END::",
+        "y",  # include thinking
+        long_thinking,
+        "::END::",
+        "hard",  # difficulty
+        "kw1, kw2",  # keywords
+        "",  # filename
+    ]
+
+    iterator = iter(inputs)
+    monkeypatch.setattr(builtins, "input", lambda *args: next(iterator))
+    monkeypatch.setattr(create_entry, "CONTENT_ROOT", str(root))
+
+    create_entry.create_new_entry()
+
+    files = list(Path(root).glob("**/*.md"))
+    assert len(files) == 1
+    text = files[0].read_text()
+    assert long_question in text
+    assert long_answer in text
+    assert long_thinking in text
+


### PR DESCRIPTION
## Summary
- ensure `create_entry.py` uses `get_multiline_input()` for the question
- add two tests with long, oddly formatted text
- patch existing test to add repo root to `sys.path` so imports work

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864715899a483228c2f8d4ec2eadb38